### PR TITLE
Mccalluc/just tests not build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - KUBERNETES_SDK_VERSION='7.0.0'
   matrix:
   - TARGET=docker
-  - TARGET=kubernetes
+  - TARGET=kompatible
 
 before_install:
 # Tips for Kubernetes on Travis come from:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,10 @@ env:
   - CHANGE_MINIKUBE_NONE_USER=true
   - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
   - KUBERNETES_VERSION=v1.9.0  # TODO: Test other versions
-  matrix:
   - KUBERNETES_SDK_VERSION='7.0.0'
+  matrix:
+  - TARGET=docker
+  - TARGET=kubernetes
 
 before_install:
 # Tips for Kubernetes on Travis come from:
@@ -57,4 +59,3 @@ deploy:
   on:
     branch: master
     python: 3.6
-    condition: "$KUBERNETES_SDK_VERSION = '7.0.0'"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,65 @@ With those tools in place, the following lines will produce the same output,
 regardless of the underlying technology. Either `import docker as sdk`
 or `import kompatible as sdk` and then
 
-```
+```python
 >>> client = sdk.from_env()
->>> client.containers.run("alpine", "echo hello world")
-b'hello world\n'
 
+>>> assert client.api
+>>> assert client.containers
+>>> assert client.images
+>>> assert client.volumes
+
+>>> [client.containers.run(
+...     "alpine", "echo hello world",
+...     name='foobar',
+...     labels={'foo': 'bar'})]
+[...'hello world\n']
+
+>>> containers = client.containers.list(all=True, filters={})
+>>> [c.name for c in containers]
+[...'foobar']
+>>> c = containers[0]
+>>> assert c.id
+>>> assert c.image
+>>> c.labels
+{...'foo': ...'bar'}
+>>> assert c.short_id
+>>> assert c.status
+
+>>> c.remove(force=True, v=True)
+>>> containers = client.containers.list(all=True, filters={})
+>>> assert len(containers) == 0
+
+```
+
+
+```
+TODO:
+    client.api.base_url
+    
+    client.containers.run(image_name,
+        name=container_spec.container_name,
+        ports={'{}/tcp'.format(container_spec.container_port): None},
+        detach=True,
+        labels=labels,
+        volumes=volumes,
+        nano_cpus=int(container_spec.cpus * 1e9),
+        environment=environment,
+        mem_reservation='{}M'.format(new_mem_reservation_mb))
+    client.containers.get(name_or_id)
+        container.logs(timestamps=True)
+        container.attrs['NetworkSettings']
+        container.attrs['Config']['Labels']
+        container.remove(force=True, v=True)
+    client.containers.list(all=True, filters=filters)
+    
+    client.images
+    client.images.pull  # Used by script, but not used by runtime.
+    # For Kubernetes, consider https://kubernetes.io/docs/concepts/containers/images/#pre-pulling-images
+    # We would need to make sure that every image is on every node we start up.
+    # Mayber other Container registries are faster than DockerHub, in which
+    # case pre-caching might be less important?
+    
+    client.volumes
+    client.volumes.create(driver='local').name
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ or `import kompatible as sdk` and then
 >>> assert c.status
 
 >>> c.remove(force=True, v=True)
->>> containers = client.containers.list(all=True, filters={})
+>>> containers = not_kube(client.containers.list(all=True, filters={}))
 >>> assert len(containers) == 0
 
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ or `import kompatible as sdk` and then
 [...'hello world\n']
 
 >>> containers = client.containers.list(all=True, filters={})
+>>> containers = [c for c in containers if 'kube' not in c.name]  # Filter for Docker
 >>> [c.name for c in containers]
 [...'foobar']
 >>> c = containers[0]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ or `import kompatible as sdk` and then
 ...     labels={'foo': 'bar'})]
 [...'hello world\n']
 
->>> containers = client.containers.list(all=True, filters={})
->>> containers = [c for c in containers if 'kube' not in c.name]  # Filter for Docker
+>>> def not_kube(containers):  # Only needed for Docker, on Travis, with Kube started.
+...     return [c for c in containers if 'kube' not in c.name]
+
+>>> containers = not_kube(client.containers.list(all=True, filters={}))
 >>> [c.name for c in containers]
 [...'foobar']
 >>> c = containers[0]

--- a/doctest_runner.py
+++ b/doctest_runner.py
@@ -12,7 +12,8 @@ if args.docker:
 else:
     import kompatible as sdk
 
-(failure_count, test_count) = doctest.testfile('README.md', globs={'sdk': sdk})
+(failure_count, test_count) = doctest.testfile(
+    'README.md', globs={'sdk': sdk}, optionflags=doctest.ELLIPSIS)
 print('{}: fail / total = {} / {}'.format(
     sdk.__name__, failure_count, test_count))
 if failure_count > 0:

--- a/kompatible/api.py
+++ b/kompatible/api.py
@@ -1,0 +1,2 @@
+class ApiClient():
+    pass

--- a/kompatible/client.py
+++ b/kompatible/client.py
@@ -1,55 +1,31 @@
-import time
+from kubernetes import config
+from kubernetes.client import configuration
 
-from kubernetes import client, config
-from kubernetes.stream import stream
+from .api import ApiClient
+from .containers import ContainersClient
+from .images import ImagesClient
+from .volumes import VolumesClient
 
 config.load_kube_config()
+configuration.assert_hostname = False
+# Trying to fix network problems on python2.7.
+# https://github.com/kubernetes-client/python/issues/144#issuecomment-282909931
 
 
 class Client():
 
     @property
     def containers(self):
-        return _Containers()
+        return ContainersClient()
 
+    @property
+    def api(self):
+        return ApiClient()
 
-class _Containers():
-    def run(self, image, command):
-        api = client.CoreV1Api()
-        name = 'todo-foobar'
+    @property
+    def images(self):
+        return ImagesClient()
 
-        pod_manifest = {
-            'apiVersion': 'v1',
-            'kind': 'Pod',
-            'metadata': {
-                'name': name
-            },
-            'spec': {
-                'containers': [{
-                    'image': image,
-                    'name': name,
-                    "args": [  # TODO: Is this necessary?
-                        "/bin/sh",
-                        "-c",
-                        "while true;do date;sleep 5; done"
-                    ]
-                }]
-            }
-        }
-
-        api.create_namespaced_pod(body=pod_manifest, namespace='default')
-
-        while True:
-            resp = api.read_namespaced_pod(name=name, namespace='default')
-            if resp.status.phase != 'Pending':
-                break
-            time.sleep(1)
-        pass
-
-        exec_command = ['/bin/sh', '-c', command]
-        resp = stream(api.connect_get_namespaced_pod_exec, name, 'default',
-                      command=exec_command,
-                      stderr=True, stdin=False,
-                      stdout=True, tty=False)
-        # Return bytes just to match behavior of Docker client.
-        return resp.encode()
+    @property
+    def volumes(self):
+        return VolumesClient()

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -1,9 +1,13 @@
 import time
+import logging
 
 from kubernetes import client
 from kubernetes.stream import stream
 
 NAMESPACE = 'default'
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
 
 
 class ContainersClient():
@@ -56,6 +60,8 @@ class ContainersClient():
 
     def list(self, all=False, filters=None):
         all_pods = self.api.list_pod_for_all_namespaces(watch=False).items
+        logger.warn('all_pods: {}'.format(
+            [(pod.metadata.name, pod.metadata.namespace) for pod in all_pods]))
         our_pods = [pod for pod in all_pods
                     if pod.metadata.namespace == NAMESPACE]
         return [_ContainerWrapper(self.api, pod) for pod in our_pods]

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -1,0 +1,86 @@
+import time
+
+from kubernetes import client
+from kubernetes.stream import stream
+
+NAMESPACE = 'default'
+
+
+class ContainersClient():
+
+    def __init__(self):
+        self.api = client.CoreV1Api()
+
+    def run(self, image, command=None,
+            name='anonymous', labels={}, environment={}):
+        pod_manifest = {
+            'apiVersion': 'v1',
+            'kind': 'Pod',
+            'metadata': {
+                'name': name,
+                'labels': labels
+            },
+            'spec': {
+                'containers': [{
+                    'image': image,
+                    'name': name,
+                    'labels': labels,
+                    "args": [  # TODO: Is this necessary?
+                        "/bin/sh",
+                        "-c",
+                        "while true;do date;sleep 5; done"
+                    ],
+                    'env': [{'name': n,
+                             'value': v} for (n, v) in environment.items()]
+                }]
+            }
+        }
+
+        self.api.create_namespaced_pod(body=pod_manifest, namespace=NAMESPACE)
+
+        while True:
+            resp = self.api.read_namespaced_pod(name=name, namespace=NAMESPACE)
+            if resp.status.phase != 'Pending':
+                break
+            time.sleep(1)
+        pass
+
+        exec_command = ['/bin/sh', '-c', command]
+        resp = stream(self.api.connect_get_namespaced_pod_exec,
+                      name, 'default',
+                      command=exec_command,
+                      stderr=True, stdin=False,
+                      stdout=True, tty=False)
+        # Return bytes just to match behavior of Docker client.
+        return resp.encode()
+
+    def list(self, all=False, filters=None):
+        all_pods = self.api.list_pod_for_all_namespaces(watch=False).items
+        our_pods = [pod for pod in all_pods
+                    if pod.metadata.namespace == NAMESPACE]
+        return [_ContainerWrapper(self.api, pod) for pod in our_pods]
+
+
+class _ContainerWrapper():
+    def __init__(self, api, pod):
+        self._api = api
+
+        meta = pod.metadata
+        containers = pod.spec.containers
+        if len(containers) > 1:
+            raise Exception(
+                'Expected single container; not {}'.format(containers))
+
+        self.id = meta.uid
+        self.image = containers[0].image
+        self.labels = meta.labels
+        self.name = meta.name
+        self.short_id = self.id[:10]
+        self.status = pod.status
+
+    def remove(self, force=None, v=None):
+        if not force or not v:
+            raise Exception('Unsupported: "force" and "v" must both be True')
+        self._api.delete_namespaced_pod(
+            self.name, NAMESPACE,
+            client.V1DeleteOptions(grace_period_seconds=0))

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -60,8 +60,6 @@ class ContainersClient():
 
     def list(self, all=False, filters=None):
         all_pods = self.api.list_pod_for_all_namespaces(watch=False).items
-        logger.warn('all_pods: {}'.format(
-            [(pod.metadata.name, pod.metadata.namespace) for pod in all_pods]))
         our_pods = [pod for pod in all_pods
                     if pod.metadata.namespace == NAMESPACE]
         return [_ContainerWrapper(self.api, pod) for pod in our_pods]

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -1,5 +1,5 @@
-import time
 import logging
+import time
 
 from kubernetes import client
 from kubernetes.stream import stream

--- a/kompatible/images.py
+++ b/kompatible/images.py
@@ -1,0 +1,2 @@
+class ImagesClient():
+    pass

--- a/kompatible/volumes.py
+++ b/kompatible/volumes.py
@@ -1,0 +1,2 @@
+class VolumesClient():
+    pass

--- a/test.sh
+++ b/test.sh
@@ -31,7 +31,8 @@ kubectl get pods
 end preflight
 
 start doctest
-python doctest_runner.py --docker
+# TODO: Need to split up the matrix: docker see the Kubernetes housekeeping.
+#python doctest_runner.py --docker
 python doctest_runner.py --kompatible
 end doctest
 

--- a/test.sh
+++ b/test.sh
@@ -31,9 +31,7 @@ kubectl get pods
 end preflight
 
 start doctest
-# TODO: Need to split up the matrix: docker see the Kubernetes housekeeping.
-#python doctest_runner.py --docker
-python doctest_runner.py --kompatible
+python doctest_runner.py --$TARGET
 end doctest
 
 #start coverage


### PR DESCRIPTION
- Use the build matrix to test docker and kompatible separately: Mostly to make it easier to tell what failed.
- More doc tests.
- Stub out the client classes we'll need.
- Using ellipsis extensively in the doc tests to cover for the differences between python versions... `b'foo'` vs `'foo'` vs `u'foo'`.
- A big TODO with everything we'll need to implement for django-docker.

We should give some thought to how to make code reviews useful going forward. Maybe the background and the motivations are hard to follow just looking at the PR and it would be better to sit down once a week and outline what's been done in that interval?

(For the time being, I'll probably default to merging first, rather than having branches off-of branches, but let me know if you disagree.)