### PR TITLE
Mccalluc/reorganize runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 cache: pip
 python:
-#- 2.7 TODO
+- 2.7
 - 3.6
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ before_install:
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.
-- until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
+- until kubectl --insecure-skip-tls-verify get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
 
 - kubectl cluster-info
 # Verify kube-addon-manager.
 # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
-- until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
+- until kubectl --insecure-skip-tls-verify -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
 # Wait for kube-dns to be ready.
-- until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done
+- until kubectl --insecure-skip-tls-verify -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done
 ## Create example Redis deployment on Kubernetes.
 #- kubectl run travis-example --image=redis --labels="app=travis-example"
 ## Make sure created pod is scheduled and running.

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ sudo: required
 
 env:
   global:
-  # This moves Kubernetes specific config files.
-  - CHANGE_MINIKUBE_NONE_USER=true
-  - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
   - KUBERNETES_VERSION=v1.9.0  # TODO: Test other versions
   - KUBERNETES_SDK_VERSION='7.0.0'
   matrix:
@@ -17,31 +14,7 @@ env:
   - TARGET=kompatible
 
 before_install:
-# Tips for Kubernetes on Travis come from:
-# https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
-# Later updated by:
-# https://github.com/LiliC/travis-minikube/blob/master/.travis.yml
-
-# Download kubectl, which is a requirement for using minikube.
-- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-# Download minikube.
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-- sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION
-# Fix the kubectl context, as it's often stale.
-- minikube update-context
-# Wait for Kubernetes to be up and ready.
-- until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
-
-- kubectl cluster-info
-# Verify kube-addon-manager.
-# kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
-- until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
-# Wait for kube-dns to be ready.
-- until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done
-## Create example Redis deployment on Kubernetes.
-#- kubectl run travis-example --image=redis --labels="app=travis-example"
-## Make sure created pod is scheduled and running.
-#- until kubectl -n default get pods -lapp=travis-example -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for travis-example deploymentavailable"; kubectl get pods -n default; done
+- '[ "$TARGET" == "docker" ] || ./install-k8s.sh'
 
 install:
 - pip install -r requirements-dev.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ before_install:
 # Fix the kubectl context, as it's often stale.
 - minikube update-context
 # Wait for Kubernetes to be up and ready.
-- until kubectl --insecure-skip-tls-verify get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
+- until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
 
 - kubectl cluster-info
 # Verify kube-addon-manager.
 # kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
-- until kubectl --insecure-skip-tls-verify -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
+- until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
 # Wait for kube-dns to be ready.
-- until kubectl --insecure-skip-tls-verify -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done
+- until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done
 ## Create example Redis deployment on Kubernetes.
 #- kubectl run travis-example --image=redis --labels="app=travis-example"
 ## Make sure created pod is scheduled and running.

--- a/install-k8s.sh
+++ b/install-k8s.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+
+# Tips for Kubernetes on Travis come from:
+# https://blog.travis-ci.com/2017-10-26-running-kubernetes-on-travis-ci-with-minikube
+# Later updated by:
+# https://github.com/LiliC/travis-minikube/blob/master/.travis.yml
+
+# This moves Kubernetes specific config files.
+export CHANGE_MINIKUBE_NONE_USER=true
+JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
+
+# Download kubectl, which is a requirement for using minikube.
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+# Download minikube.
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.25.2/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+sudo minikube start --vm-driver=none --kubernetes-version=$KUBERNETES_VERSION
+# Fix the kubectl context, as it's often stale.
+minikube update-context
+# Wait for Kubernetes to be up and ready.
+until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kubernetes"; done
+
+kubectl cluster-info
+# Verify kube-addon-manager.
+# kube-addon-manager is responsible for managing other kubernetes components, such as kube-dns, dashboard, storage-provisioner..
+until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-addon-manager"; kubectl get pods --all-namespaces; done
+# Wait for kube-dns to be ready.
+until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; echo "waiting for kube-dns"; kubectl get pods --all-namespaces; done

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -13,6 +13,9 @@ logger = logging.getLogger(__name__)
 class ContainersClient():
 
     def __init__(self):
+        config = client.Configuration()
+        config.verify_ssl = False
+        client.Configuration.set_default(config)
         self.api = client.CoreV1Api()
 
     def run(self, image, command=None,

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class ContainersClient():
 
     def __init__(self):
-        if version_info.major_version == 2:
+        if version_info[0] == 2:
             # On Python2 (not Python3) was hitting:
             #      File ".../stream/stream.py", line 32, in stream
             #        return func(*args, **kwargs)

--- a/kompatible/containers.py
+++ b/kompatible/containers.py
@@ -1,6 +1,6 @@
 import logging
-from sys import version_info
 import time
+from sys import version_info
 
 from kubernetes import client
 from kubernetes.stream import stream

--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,12 @@ docker info
 docker info | grep 'Operating System' \
     || die 'Make sure Docker is running'
 
-kubectl cluster-info
-# TODO: What is a good check for kubernetes?
+if which kubectl; then
+    kubectl cluster-info
+    kubectl get pods
+    [ -z "`kubectl get pods`" ] \
+        || die 'Kill pods before running tests: "kubectl delete pods --all"'  # Can take a while...
+fi
 
 # Running locally, Kubernetes housekeeping containers are inside the VM.
 # On Travis, there is no VM, so Docker will see Kubernetes containers.
@@ -23,10 +27,6 @@ kubectl cluster-info
 docker ps -a
 [ -z "`docker ps -a | grep -v kube | tail -n +2`" ] \
     || die 'Kill containers before running tests: "docker ps -qa | xargs docker stop | xargs docker rm"'
-
-kubectl get pods
-[ -z "`kubectl get pods`" ] \
-    || die 'Kill pods before running tests: "kubectl delete pods --all"'  # Can take a while...
 
 end preflight
 


### PR DESCRIPTION
- Test on Python2
- Move the k8s install to its own script, and do not run when we're just testing docker
- Disable ssl checks on Python2; not ideal, but I haven't found a better solution