### PR TITLE
Mccalluc/cleaner tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, checkout this project, and install dependencies:
 `pip install -r requirements-dev.txt`.
 Then, make sure you have installed and started
 [Docker](https://docs.docker.com/docker-for-mac/install/)
-and/or [Minikube](https://kubernetes.io/docs/tutorials/hello-minikube/#create-a-minikube-cluster)
+and/or [Minikube](https://kubernetes.io/docs/tutorials/hello-minikube/#create-a-minikube-cluster).
 
 With those tools in place, either
 `import docker as sdk` or `import kompatible as sdk`

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ and in the latter it's Kubernetes pods.
 ...     "alpine", "echo hello world",
 ...     name='foobar',
 ...     labels={'foo': 'bar'})]
-[...'hello world\n']
+['hello world\n']
 
 >>> def not_kube(containers):  # Only needed for Docker, on Travis, with k8s started.
 ...     return [c for c in containers if 'kube' not in c.name]
 
 >>> containers = not_kube(client.containers.list(all=True, filters={}))
 >>> [c.name for c in containers]
-[...'foobar']
+['foobar']
 >>> c = containers[0]
 
 >>> c.remove(force=True, v=True)
@@ -52,7 +52,7 @@ and in the latter it's Kubernetes pods.
 >>> assert c.id
 >>> assert c.image
 >>> c.labels
-{...'foo': ...'bar'}
+{'foo': 'bar'}
 >>> assert c.short_id
 >>> assert c.status
 

--- a/doctest_runner.py
+++ b/doctest_runner.py
@@ -1,20 +1,41 @@
 import argparse
 import doctest
 
-parser = argparse.ArgumentParser(description='Run doc tests')
-group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('--docker', action='store_true')
-group.add_argument('--kompatible', action='store_true')
 
-args = parser.parse_args()
-if args.docker:
-    import docker as sdk
-else:
-    import kompatible as sdk
+class UnfussyOutputChecker(doctest.OutputChecker):
+    pass
 
-(failure_count, test_count) = doctest.testfile(
-    'README.md', globs={'sdk': sdk}, optionflags=doctest.ELLIPSIS)
-print('{}: fail / total = {} / {}'.format(
-    sdk.__name__, failure_count, test_count))
-if failure_count > 0:
-    exit(1)
+
+def get_sdk():
+    parser = argparse.ArgumentParser(description='Run doc tests')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--docker', action='store_true')
+    group.add_argument('--kompatible', action='store_true')
+
+    args = parser.parse_args()
+    if args.docker:
+        import docker as sdk
+    else:
+        import kompatible as sdk
+    return sdk
+
+
+def main():
+    filename = 'README.md'
+    with open(filename) as f:
+        readme = f.read()
+    examples = doctest.DocTestParser().get_doctest(
+        string=readme, globs={'sdk': get_sdk()},
+        name=filename, filename=None, lineno=0)
+
+    runner = doctest.DocTestRunner(
+        checker=UnfussyOutputChecker(),
+        optionflags=doctest.ELLIPSIS)
+    runner.run(examples)
+    (failed, attempted) = runner.summarize()
+    if failed > 0:
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/doctest_runner.py
+++ b/doctest_runner.py
@@ -1,9 +1,15 @@
 import argparse
 import doctest
+from re import sub
 
 
 class UnfussyOutputChecker(doctest.OutputChecker):
-    pass
+    def check_output(self, want, got, optionflags):
+        if optionflags:
+            raise Exception('options are not supported')
+        got = sub(r"\bu'", "'", got)  # python 2
+        got = sub(r"\bb'", "'", got)  # python 3
+        return want == got
 
 
 def get_sdk():
@@ -28,9 +34,7 @@ def main():
         string=readme, globs={'sdk': get_sdk()},
         name=filename, filename=None, lineno=0)
 
-    runner = doctest.DocTestRunner(
-        checker=UnfussyOutputChecker(),
-        optionflags=doctest.ELLIPSIS)
+    runner = doctest.DocTestRunner(checker=UnfussyOutputChecker())
     runner.run(examples)
     (failed, attempted) = runner.summarize()
     if failed > 0:


### PR DESCRIPTION
Dig into the doc test machinery so we can get it to ignore the differences in output between 2 and 3. The machinery itself isn't too complicated, and this makes the tests much more robust: `...` is a wild card that could swallow anything.